### PR TITLE
Fix: reduce unnecessary entitlements

### DIFF
--- a/nix.novaextension/extension.json
+++ b/nix.novaextension/extension.json
@@ -16,8 +16,7 @@
   "activationEvents": ["onWorkspaceContains:*.nix"],
 
   "entitlements": {
-    "process": true,
-    "filesystem": "readwrite"
+    "process": true
   },
 
   "config": [


### PR DESCRIPTION
- Remove `filesystem` entitlements since it's not being used