### PR TITLE
v0.5.0 release prep

### DIFF
--- a/nix.novaextension/CHANGELOG.md
+++ b/nix.novaextension/CHANGELOG.md
@@ -1,8 +1,25 @@
+## v0.5.0 - 2021-07-25
+
+### Chore & Maintenance
+
+- `[core]` Update dev dependencies
+
+### Features
+
+- `[core]` Add initial localization support for German & French. ([#14](https://github.com/hansjhoffman/nova-nix/pull/14))
+
+### Fixes
+
+- `[formatter]` Only activate on `.nix` files instead of on a workspace that contains `.nix` files. ([#16](https://github.com/hansjhoffman/nova-nix/pull/16))
+- `[formatter]` Restrict format command to only files with `.nix` extension. ([#15](https://github.com/hansjhoffman/nova-nix/pull/15))
+- `[core]` Remove `filesystem` entitlements -- not needed. ([#13](https://github.com/hansjhoffman/nova-nix/pull/13))
+- `[formatter]` Add composite disposable for proper extension cleanup. ([#12](https://github.com/hansjhoffman/nova-nix/pull/12))
+
 ## v0.4.0 - 2021-07-23
 
 ### Chore & Maintenance
 
-- Update extension dependencies
+- `[core]` Update extension dependencies
 
 ### Fixes
 

--- a/nix.novaextension/extension.json
+++ b/nix.novaextension/extension.json
@@ -3,7 +3,7 @@
   "name": "Nix",
   "organization": "@hansjhoffman",
   "description": "Provides syntax highlighting and formatting for Nix.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "categories": ["commands", "formatters", "languages"],
   "license": "MIT",
   "repository": "https://github.com/hansjhoffman/nova-nix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nova-nix",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Provides syntax highlighting and formatting for Nix.",
   "main": "src/index.ts",
   "author": "Hans Hoffman",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",
-    "@rollup/plugin-node-resolve": "^13.0.2",
+    "@rollup/plugin-node-resolve": "^13.0.4",
     "@rollup/plugin-typescript": "^8.2.3",
     "@types/nova-editor-node": "^4.1.3",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
@@ -40,7 +40,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "husky": "^7.0.1",
     "is-ci": "^3.0.0",
-    "lint-staged": "^11.1.0",
+    "lint-staged": "^11.1.1",
     "prettier": "^2.3.2",
     "rollup": "^2.53.3",
     "rollup-plugin-typescript2": "^0.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,10 +93,10 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-node-resolve@^13.0.2":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.2.tgz#bfe58e9bfc7284ee0fabc6da7fabcb268f04e0a4"
-  integrity sha512-hv+eAMcA2hQ7qvPVcXbtIyc0dtue4jMyA2sCW4IMkrmh+SeDDEHg1MXTv65VPpKdtjvWzN3+4mHAEl4rT+zgzQ==
+"@rollup/plugin-node-resolve@^13.0.4":
+  version "13.0.4"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.4.tgz#b10222f4145a019740acb7738402130d848660c0"
+  integrity sha512-eYq4TFy40O8hjeDs+sIxEH/jc9lyuI2k9DM557WN6rO5OpnC2qXMBNj4IKH1oHrnAazL49C5p0tgP0/VpqJ+/w==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
@@ -1280,10 +1280,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.1.0.tgz#a21d67ffe4516e907635adeaf6d6450d8cffb4e4"
-  integrity sha512-pzwEf+NKbTauAlk7gPPwTfulRXESEPZCSFXYfg20F220UOObebxu5uL5mkr9csQLNOM2Ydfrt3DJXakzAL7aaQ==
+lint-staged@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.1.1.tgz#9c2018b872654cf80b2b1ff5a10b6b74aef6e300"
+  integrity sha512-eTNGe6i78PSUUH2BZi1gZmGmNfb8IeN4z2OzMYxSZ1qnP1WXKn1E7D+OHwLbRDm/wQINnzIj0bsKJ6lLVSuZiQ==
   dependencies:
     chalk "^4.1.1"
     cli-truncate "^2.1.0"


### PR DESCRIPTION
## v0.5.0 - 2021-07-25

### Chore & Maintenance

- `[core]` Update dev dependencies

### Features

- `[core]` Add initial localization support for German & French. ([#14](https://github.com/hansjhoffman/nova-nix/pull/14))

### Fixes

- `[formatter]` Only activate on `.nix` files instead of on a workspace that contains `.nix` files. ([#16](https://github.com/hansjhoffman/nova-nix/pull/16))
- `[formatter]` Restrict format command to only files with `.nix` extension. ([#15](https://github.com/hansjhoffman/nova-nix/pull/15))
- `[core]` Remove `filesystem` entitlements -- not needed. ([#13](https://github.com/hansjhoffman/nova-nix/pull/13))
- `[formatter]` Add composite disposable for proper extension cleanup. ([#12](https://github.com/hansjhoffman/nova-nix/pull/12))